### PR TITLE
fixed thumbnail align

### DIFF
--- a/jm-react-site/src/components/Thumbnail/Thumbnail.styled.js
+++ b/jm-react-site/src/components/Thumbnail/Thumbnail.styled.js
@@ -28,6 +28,7 @@ const ContainerSingle = css`
     ${(props) =>
       !props.thumbtab &&
       css`
+        align-content: center;
         height: 50vh;
       `}
   }


### PR DESCRIPTION
set to align-content: center. hopefully fixes the vertical center on thumbnail.js images.